### PR TITLE
Fix up a panic if a fmt::Display itself failed during parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ version = "0.1.2"
 Any Rust primitive numeric type can be encoded in a `Bitstring`:
 
 ```rust
-let decimal = decstr::Bitstring::try_parse_str("123.44")?;
+let decimal = decstr::Bitstring::from(123.44);
 
 // 123.44
 println!("{}", decimal);

--- a/examples/arbitrary-precision.rs
+++ b/examples/arbitrary-precision.rs
@@ -1,14 +1,58 @@
 #[cfg(feature = "arbitrary-precision")]
 fn main() -> Result<(), decstr::Error> {
-    let decimal = decstr::BigBitstring::try_parse_str(include_str!("pi.txt"))?;
+    let decimal = decstr::BigBitstring::try_parse(Pi("./examples/pi.txt"))?;
 
     println!("{}", decimal);
     println!("{:?}", decimal.as_le_bytes());
-    
+
     Ok(())
 }
 
 #[cfg(not(feature = "arbitrary-precision"))]
-fn main() {
-    
+fn main() {}
+
+use std::{
+    fmt,
+    fs,
+    io::{
+        self,
+        Read,
+    },
+    str,
+};
+
+/**
+An example that streams a number through `fmt::Display` from a file.
+
+We could use `include_str!` here, but this example demonstrates `decstr`'s
+stateful parsing of numbers.
+*/
+pub struct Pi(&'static str);
+
+impl fmt::Display for Pi {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut pi = fs::File::open(self.0).unwrap();
+
+        let mut buf = [0; 16];
+
+        loop {
+            match pi.read(&mut buf) {
+                // If we successfully read 0 bytes then we're finished
+                Ok(0) => {
+                    break;
+                }
+                // If we read some bytes then forward them through the formatter as UTF8
+                Ok(n) => {
+                    let buf = str::from_utf8(&buf[..n]).unwrap();
+                    f.write_str(buf)?;
+                }
+                // If the read failed, but can be retried then try again
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                // If the read failed for any other reason then return
+                Err(_) => return Err(fmt::Error),
+            }
+        }
+
+        Ok(())
+    }
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -3,7 +3,7 @@ fn main() -> Result<(), decstr::Error> {
 
     println!("{}", decimal);
     println!("{:?}", decimal.as_le_bytes());
-    
+
     let small = decstr::Bitstring::from(1u8);
     let large = decstr::Bitstring::from(u128::MAX);
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,5 +1,5 @@
 fn main() -> Result<(), decstr::Error> {
-    let decimal = decstr::Bitstring::try_parse_str("123.44")?;
+    let decimal = decstr::Bitstring::from(123.44);
 
     println!("{}", decimal);
     println!("{:?}", decimal.as_le_bytes());

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -459,7 +459,7 @@ fn write_digits(
     out: impl fmt::Write,
 ) -> Result<(), fmt::Error> {
     write_content(
-        unsafe { str::from_utf8_unchecked(&digits) },
+        str::from_utf8(&digits).map_err(|_| fmt::Error)?,
         digits.len(),
         written,
         out,
@@ -472,7 +472,7 @@ fn write_declet(
     out: impl fmt::Write,
 ) -> Result<(), fmt::Error> {
     write_content(
-        unsafe { str::from_utf8_unchecked(&declet) },
+        str::from_utf8(&declet).map_err(|_| fmt::Error)?,
         declet.len(),
         written,
         out,
@@ -554,7 +554,7 @@ fn write_all_as_scientific(
     } else {
         if let Some(declet) = declets.next() {
             write_content(
-                unsafe { str::from_utf8_unchecked(&[declet[0], b'.', declet[1], declet[2]]) },
+                str::from_utf8(&[declet[0], b'.', declet[1], declet[2]]).map_err(|_| fmt::Error)?,
                 1,
                 written,
                 &mut out,

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,9 +64,23 @@ enum ParseErrorKind {
     Char { got: u8 },
     End,
     BufferTooSmall,
+    Source,
 }
 
 impl ParseError {
+    /**
+    The source of text itself failed while streaming a number.
+    */
+    pub(crate) fn source() -> Self {
+        ParseError {
+            expected: "",
+            kind: ParseErrorKind::Source,
+        }
+    }
+
+    /**
+    A pre-allocated buffer was too small to fit the complete number.
+    */
     pub(crate) fn buffer_too_small() -> Self {
         ParseError {
             expected: "",
@@ -74,6 +88,9 @@ impl ParseError {
         }
     }
 
+    /**
+    Encountered an unexpected character while parsing a number.
+    */
     pub(crate) fn unexpected_char(got: u8, expected: &'static str) -> Self {
         ParseError {
             expected,
@@ -81,6 +98,9 @@ impl ParseError {
         }
     }
 
+    /**
+    Encountered an unexpected end of input while parsing a number.
+    */
     pub(crate) fn unexpected_end(expected: &'static str) -> Self {
         ParseError {
             expected,
@@ -100,6 +120,9 @@ impl fmt::Display for ParseError {
             }
             ParseErrorKind::BufferTooSmall => {
                 write!(f, "the buffer is too small")?;
+            }
+            ParseErrorKind::Source => {
+                write!(f, "the source produced an error while parsing")?;
             }
         };
 
@@ -144,6 +167,9 @@ impl fmt::Display for OverflowError {
 }
 
 impl OverflowError {
+    /**
+    Encoding a number of the given width into a buffer would require rounding.
+    */
     pub(crate) fn would_overflow(
         max_width_bytes: usize,
         required_width_bytes: usize,
@@ -155,6 +181,9 @@ impl OverflowError {
         }
     }
 
+    /**
+    An encoding buffer returned a different size to the exact size requested.
+    */
     pub(crate) fn exact_size_mismatch(
         got_width_bytes: usize,
         required_width_bytes: usize,
@@ -167,6 +196,9 @@ impl OverflowError {
         }
     }
 
+    /**
+    An exponent couldn't fit in a buffer of the given width.
+    */
     pub(crate) fn exponent_out_of_range(
         max_width_bytes: usize,
         note: &'static str,
@@ -203,6 +235,9 @@ pub struct ConvertError {
 }
 
 impl ConvertError {
+    /**
+    Converting into the given numeric type would overflow.
+    */
     pub(crate) fn would_overflow(target: &'static str) -> Self {
         ConvertError {
             target,
@@ -210,6 +245,9 @@ impl ConvertError {
         }
     }
 
+    /**
+    Converting into the given integer type would require rounding.
+    */
     pub(crate) fn non_integer(target: &'static str) -> Self {
         ConvertError {
             target,

--- a/src/num.rs
+++ b/src/num.rs
@@ -436,7 +436,8 @@ where
     let parsed = parser.end().expect("failed to finish parsing");
 
     // Convert the parsed value into a float
-    unsafe { str::from_utf8_unchecked(parsed.finite_buf.get_ascii()) }
+    str::from_utf8(parsed.finite_buf.get_ascii())
+        .ok()?
         .parse()
         .ok()
 }

--- a/src/text/finite.rs
+++ b/src/text/finite.rs
@@ -227,7 +227,7 @@ impl<B: TextWriter> FiniteParser<B> {
     }
 
     pub fn unwrap_context(&mut self, _: fmt::Error) -> ParseError {
-        self.error.take().expect("missing error context")
+        self.error.take().unwrap_or_else(ParseError::source)
     }
 }
 

--- a/src/text/infinity.rs
+++ b/src/text/infinity.rs
@@ -107,7 +107,7 @@ impl<B: TextWriter> InfinityParser<B> {
     }
 
     pub fn unwrap_context(&mut self, _: fmt::Error) -> ParseError {
-        self.error.take().expect("missing error context")
+        self.error.take().unwrap_or_else(ParseError::source)
     }
 
     fn is_at_start(&self) -> bool {

--- a/src/text/nan.rs
+++ b/src/text/nan.rs
@@ -151,7 +151,7 @@ impl<B: TextWriter> NanParser<B> {
     }
 
     pub fn unwrap_context(&mut self, _: fmt::Error) -> ParseError {
-        self.error.take().expect("missing error context")
+        self.error.take().unwrap_or_else(ParseError::source)
     }
 
     fn is_at_start(&self) -> bool {


### PR DESCRIPTION
If an implementation of `fmt::Display` itself fails then we'll panic attempting to unwrap our error context. It might be time to look at some better basis for parsing than `std::fmt`, which makes tracking errors difficult.