### PR TITLE
Prepare for 0.1.3 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "decstr"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add `decstr` to your `Cargo.toml`:
 
 ```toml
 [dependencies.decstr]
-version = "0.1.2"
+version = "0.1.3"
 ```
 
 Any Rust primitive numeric type can be encoded in a `Bitstring`:


### PR DESCRIPTION
## What's Changed
* A few more cleanups by @KodrAus in https://github.com/KodrAus/decstr/pull/7
* Fix up a panic if a fmt::Display itself failed during parsing by @KodrAus in https://github.com/KodrAus/decstr/pull/8