### PR TITLE
fix warnings and add missing derives

### DIFF
--- a/src/binary/buf.rs
+++ b/src/binary/buf.rs
@@ -250,11 +250,11 @@ pub(crate) fn minimum_storage_width_bits_for_integer_exponent<N: BinaryExponentM
         //
         // Since the general case over-provisions, for these common sizes we just check them
         // rather than computing so they're always exact.
-        Some(emax) if emax >= -101 && emax <= 90 => 32,
-        Some(emax) if emax >= -398 && emax <= 369 => 64,
-        Some(emax) if emax >= -1559 && emax <= 1512 => 96,
-        Some(emax) if emax >= -6176 && emax <= 6111 => 128,
-        Some(emax) if emax >= -24617 && emax <= 24534 => 160,
+        Some(emax) if (-101..=90).contains(&emax) => 32,
+        Some(emax) if (-398..=369).contains(&emax) => 64,
+        Some(emax) if (-1559..=1512).contains(&emax) => 96,
+        Some(emax) if (-6176..=6111).contains(&emax) => 128,
+        Some(emax) if (-24617..=24534).contains(&emax) => 160,
         // If the exponent is not small, compute an appropriate width
         _ => calculate_minimum_storage_width_bits_for_integer_exponent(emax),
     }

--- a/src/binary/buf/dynamic.rs
+++ b/src/binary/buf/dynamic.rs
@@ -96,8 +96,9 @@ impl Integer for DynamicBinaryExponent {
         DynamicBinaryExponent(i32::from_i32(exp))
     }
 
+    #[inline]
     fn to_i32(&self) -> Option<i32> {
-        (self.0).try_into().ok()
+        Some(self.0)
     }
 
     fn is_negative(&self) -> bool {

--- a/src/binary/combination.rs
+++ b/src/binary/combination.rs
@@ -153,7 +153,7 @@ pub fn encode_combination_finite<D: BinaryBuf>(
     // If the bytes of the exponent are not aligned with the bytes in the decimal then
     // they'll need to be shifted into position.
     else {
-        let decimal_byte_plus_1_shift = (8 - decimal_byte_shift) as u32;
+        let decimal_byte_plus_1_shift = 8 - decimal_byte_shift;
 
         while decimal_byte_index < max_decimal_byte_index {
             buf[decimal_byte_index] |= exponent[exponent_byte_index] << decimal_byte_shift;
@@ -178,7 +178,7 @@ pub fn encode_combination_finite<D: BinaryBuf>(
         most_significant_exponent_offset(exponent_bits);
 
     let most_significant_exponent =
-        exponent[most_significant_exponent_index] >> most_significant_exponent_offset - 2;
+        exponent[most_significant_exponent_index] >> (most_significant_exponent_offset - 2);
 
     // Write the final bits of the exponent
     // These will be shifted and masked by the combination field
@@ -312,7 +312,7 @@ pub fn decode_combination_finite<D: BinaryBuf>(decimal: &D) -> (D::Exponent, Mos
             };
 
         (
-            most_significant_exponent << most_significant_exponent_offset - 2,
+            most_significant_exponent << (most_significant_exponent_offset - 2),
             most_significant_exponent_index,
             most_significant_digit_bcd,
         )
@@ -365,7 +365,7 @@ pub fn decode_combination_finite<D: BinaryBuf>(decimal: &D) -> (D::Exponent, Mos
     // There's a special case for sizes where the 2 most significant bits are in their own
     // final byte of the exponent.
     else {
-        let decimal_byte_plus_1_shift = (8 - decimal_byte_shift) as u32;
+        let decimal_byte_plus_1_shift = 8 - decimal_byte_shift;
 
         D::Exponent::from_le_bytes(iter::from_fn(|| {
             // If there are more than 2 bytes left then squash them into the next byte of the exponent.

--- a/src/binary/significand.rs
+++ b/src/binary/significand.rs
@@ -106,9 +106,9 @@ pub fn encode_significand_trailing_digits_repeat<D: BinaryBuf>(
 /**
 Decode and stream the trailing digits encoded into the decimal.
 */
-pub fn decode_significand_trailing_declets<'a, D: BinaryBuf>(
-    decimal: &'a D,
-) -> impl Iterator<Item = [u8; 3]> + 'a {
+pub fn decode_significand_trailing_declets<D: BinaryBuf>(
+    decimal: &D,
+) -> impl Iterator<Item = [u8; 3]> + '_ {
     let mut bit_index = decimal.trailing_significand_width_bits();
 
     let decimal = decimal.bytes();
@@ -579,7 +579,7 @@ fn encode_bcd_declet_to_dpd(bcd: u16, decimal: &mut [u8], decimal_bit_index: &mu
     let decimal_byte_index = *decimal_bit_index / 8;
 
     decimal[decimal_byte_index] |= (dpd << decimal_byte_shift) as u8;
-    decimal[decimal_byte_index + 1] |= (dpd >> 8 - decimal_byte_shift) as u8;
+    decimal[decimal_byte_index + 1] |= (dpd >> (8 - decimal_byte_shift)) as u8;
 
     *decimal_bit_index += 10;
 }

--- a/src/bitstring.rs
+++ b/src/bitstring.rs
@@ -345,7 +345,7 @@ macro_rules! try_d2f {
             Try convert a decimal into a binary floating point.
             */
             pub fn $convert(&self) -> Option<$f> {
-                Some($crate::convert::decimal_to_binary_float(&self.0).ok()?)
+                $crate::convert::decimal_to_binary_float(&self.0).ok()
             }
         }
 

--- a/src/bitstring/dynamic.rs
+++ b/src/bitstring/dynamic.rs
@@ -26,7 +26,7 @@ impl Bitstring {
     big to fit in a `Bitstring`.
     */
     pub fn try_from_le_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        if bytes.len() == 0 || bytes.len() % 4 != 0 {
+        if bytes.is_empty() || bytes.len() % 4 != 0 {
             Err(OverflowError::exact_size_mismatch(
                 bytes.len(),
                 bytes.len() + 4 - (bytes.len() % 4),

--- a/src/bitstring/fixed128.rs
+++ b/src/bitstring/fixed128.rs
@@ -10,6 +10,7 @@ use crate::{
 /**
 A 128bit decimal number.
 */
+#[derive(Clone, Copy)]
 pub struct Bitstring128(FixedBinaryBuf<16, i32>);
 
 impl Bitstring128 {

--- a/src/bitstring/fixed64.rs
+++ b/src/bitstring/fixed64.rs
@@ -10,6 +10,7 @@ use crate::{
 /**
 A 64bit decimal number.
 */
+#[derive(Clone, Copy)]
 pub struct Bitstring64(FixedBinaryBuf<8, i32>);
 
 impl Bitstring64 {

--- a/src/convert/from_int.rs
+++ b/src/convert/from_int.rs
@@ -52,7 +52,7 @@ pub(crate) fn decimal_to_int<D: BinaryBuf, I: Integer>(decimal: &D) -> Result<I,
                 .ok_or_else(|| ConvertError::would_overflow(type_name::<I>()))
         }
         // ±1230e-1
-        Some(exponent) if (exponent.abs() as usize) < decimal.precision_digits() => {
+        Some(exponent) if (exponent.unsigned_abs() as usize) < decimal.precision_digits() => {
             let trailing_significand = decode_significand_trailing_declets(decimal);
 
             let mut digits = Some(msd.get_ascii())
@@ -64,7 +64,7 @@ pub(crate) fn decimal_to_int<D: BinaryBuf, I: Integer>(decimal: &D) -> Result<I,
                 is_sign_negative(decimal),
                 digits
                     .by_ref()
-                    .take(decimal.precision_digits() - (exponent.abs() as usize)),
+                    .take(decimal.precision_digits() - (exponent.unsigned_abs() as usize)),
             )
             .ok_or_else(|| ConvertError::would_overflow(type_name::<I>()))?;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -128,7 +128,7 @@ impl fmt::Display for ParseError {
 
         if self.expected.len() == 1 {
             write!(f, ", expected `{}`", self.expected)?;
-        } else if self.expected.len() > 0 {
+        } else if !self.expected.is_empty() {
             write!(f, ", expected {}", self.expected)?;
         }
 
@@ -158,7 +158,7 @@ impl fmt::Display for OverflowError {
             write!(f, "; the width needed is `{}` bytes", required_width_bytes)?;
         }
 
-        if self.note.len() > 0 {
+        if !self.note.is_empty() {
             write!(f, "; {}", self.note)?;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ This library does support very high precision in no-std, and can work with arbit
 */
 
 #![deny(missing_docs)]
-#![allow(const_item_mutation)]
+#![allow(const_item_mutation, clippy::derivable_impls, clippy::comparison_chain)]
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 
 extern crate core;
@@ -121,7 +121,7 @@ mod tests {
         let mut s = String::new();
 
         for b in b {
-            if s.len() > 0 {
+            if !s.is_empty() {
                 s.write_char('_').expect("infallible string write");
             }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -212,7 +212,7 @@ impl<B: TextWriter> DecimalParser<B> {
     }
 
     pub fn parse_ascii(&mut self, mut ascii: &[u8]) -> Result<(), ParseError> {
-        while ascii.len() > 0 {
+        while !ascii.is_empty() {
             match self.0 {
                 // If we're parsing a finite number then forward the remaining input to it
                 DecimalParserInner::Finite(ref mut finite) => return finite.parse_ascii(ascii),
@@ -463,7 +463,6 @@ mod tests {
                         decimal_point: Some(ParsedDecimalPoint {
                             decimal_point_range: 2..3,
                         }),
-                        ..Default::default()
                     },
                     finite_exponent: Some(ParsedExponent {
                         exponent_is_negative: false,
@@ -882,11 +881,10 @@ mod tests {
 
     #[test]
     fn parse_finite_invalid() {
-        for (input, expected_err) in &[("", "unexpected end of input, expected a sign or digit")] {
-            let actual_err = FiniteParser::parse_str(input).unwrap_err();
+        let (input, expected_err) = &("", "unexpected end of input, expected a sign or digit");
+        let actual_err = FiniteParser::parse_str(input).unwrap_err();
 
-            assert_eq!(expected_err, &actual_err.to_string(), "{}", input);
-        }
+        assert_eq!(expected_err, &actual_err.to_string(), "{}", input);
     }
 
     #[test]

--- a/src/text/finite.rs
+++ b/src/text/finite.rs
@@ -52,10 +52,11 @@ impl<B: TextWriter> FiniteParser<B> {
 
     pub fn checked_push_significand_digit(&mut self, digit: u8) -> Result<(), ParseError> {
         if self.buf.remaining_capacity() == Some(0) {
-            return Err(ParseError::buffer_too_small());
+            Err(ParseError::buffer_too_small())
+        } else {
+            self.push_significand_digit(digit);
+            Ok(())
         }
-
-        Ok(self.push_significand_digit(digit))
     }
 
     pub(in crate::text) fn push_significand_digit(&mut self, digit: u8) {
@@ -67,10 +68,11 @@ impl<B: TextWriter> FiniteParser<B> {
 
     pub fn checked_significand_is_negative(&mut self) -> Result<(), ParseError> {
         if self.buf.remaining_capacity() == Some(0) {
-            return Err(ParseError::buffer_too_small());
+            Err(ParseError::buffer_too_small())
+        } else {
+            self.significand_is_negative();
+            Ok(())
         }
-
-        Ok(self.significand_is_negative())
     }
 
     pub(in crate::text) fn significand_is_negative(&mut self) {
@@ -95,10 +97,11 @@ impl<B: TextWriter> FiniteParser<B> {
 
     pub fn checked_begin_exponent(&mut self) -> Result<(), ParseError> {
         if self.buf.remaining_capacity() == Some(0) {
-            return Err(ParseError::buffer_too_small());
+            Err(ParseError::buffer_too_small())
+        } else {
+            self.begin_exponent();
+            Ok(())
         }
-
-        Ok(self.begin_exponent())
     }
 
     pub(in crate::text) fn begin_exponent(&mut self) {
@@ -131,7 +134,7 @@ impl<B: TextWriter> FiniteParser<B> {
         // If there's no exponent then parse the significand
         // The number may be split across multiple calls to `write_str`
         if self.exponent.is_none() {
-            while ascii.len() > 0 {
+            while !ascii.is_empty() {
                 match ascii[0] {
                     // Push a digit to the significand
                     b'0'..=b'9' => {
@@ -170,7 +173,7 @@ impl<B: TextWriter> FiniteParser<B> {
         // The format for the exponent is simpler than the significand
         // It's really just a simple integer
         if let Some(ref mut exponent) = self.exponent {
-            while ascii.len() > 0 {
+            while !ascii.is_empty() {
                 match ascii[0] {
                     // Push a digit to the exponent
                     b'0'..=b'9' => {

--- a/src/text/infinity.rs
+++ b/src/text/infinity.rs
@@ -21,7 +21,7 @@ pub struct InfinityParser<B> {
     error: Option<ParseError>,
 }
 
-const INFINITY_BUF_EXPECTING: &'static [u8] = b"infinity";
+const INFINITY_BUF_EXPECTING: &[u8] = b"infinity";
 
 impl<B: TextWriter> InfinityParser<B> {
     pub fn begin(buf: B) -> Self {


### PR DESCRIPTION
Please don't hesitate to ask for any details, or request things be done differently.

I derived the missing Clone and Copy for Bitstring64 and Bitstring128.

And the reason for the the globally allowed `clippy::derivable_impls` is because it complained about a couple of manually Default impls that could be derived, but I think it's more clear in the context of multiple manualy derives with non-obvious fields. And in the case of `clippy::comparison_chain` it complained about an if chain that couldn't be transformed into match because a match can't use dynamic values, so it doesn't seem very smart and I disabled it.

