### PR TITLE
Ignore the specific NAN encoded by f32/f64::NAN

### DIFF
--- a/src/bitstring.rs
+++ b/src/bitstring.rs
@@ -72,7 +72,7 @@ macro_rules! try_s2d {
             /**
             Try parse a decimal from a string.
 
-            This method is more efficient that `try_parse` if you already have a string to parse.
+            This method is more efficient than `try_parse` if you already have a string to parse.
             */
             pub fn try_parse_str(s: &str) -> Result<$d, $crate::Error> {
                 Ok($d($crate::convert::decimal_from_str(s)?))
@@ -251,6 +251,10 @@ macro_rules! f2d {
             let _ = $d::$convert($f::MIN);
             let _ = $d::$convert($f::MAX);
             let _ = $d::$convert($f::MIN_POSITIVE);
+
+            assert!($d::$convert($f::NAN).is_nan());
+            assert!($d::$convert($f::INFINITY).is_infinite());
+            assert!($d::$convert($f::NEG_INFINITY).is_infinite());
         }
     };
 }
@@ -334,6 +338,11 @@ macro_rules! try_f2d {
                 "{} should not have been converted",
                 $f::MIN_POSITIVE
             );
+
+            // NAN and INFINITY constants should still convert
+            assert!($d::$convert($f::NAN).unwrap().is_nan());
+            assert!($d::$convert($f::INFINITY).unwrap().is_infinite());
+            assert!($d::$convert($f::NEG_INFINITY).unwrap().is_infinite());
         }
     };
 }

--- a/src/bitstring/fixed128.rs
+++ b/src/bitstring/fixed128.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 /**
-A 128bit decimal number.
+A [128bit decimal number](https://en.wikipedia.org/wiki/Decimal128_floating-point_format).
 */
 #[derive(Clone, Copy)]
 pub struct Bitstring128(FixedBinaryBuf<16, i32>);

--- a/src/bitstring/fixed32.rs
+++ b/src/bitstring/fixed32.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 /**
-A 32bit decimal number.
+A [32bit decimal number](https://en.wikipedia.org/wiki/Decimal32_floating-point_format).
 */
 #[derive(Clone, Copy)]
 pub struct Bitstring32(FixedBinaryBuf<4, i32>);

--- a/src/bitstring/fixed64.rs
+++ b/src/bitstring/fixed64.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 /**
-A 64bit decimal number.
+A [64bit decimal number](https://en.wikipedia.org/wiki/Decimal64_floating-point_format).
 */
 #[derive(Clone, Copy)]
 pub struct Bitstring64(FixedBinaryBuf<8, i32>);

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -92,6 +92,14 @@ pub(crate) fn decimal_from_parsed<D: BinaryBuf, T: TextBuf>(
                     let fractional_digits = &buf[fractional_range];
 
                     // Account for the fractional part of the number
+                    // This is where the exponent range that an end-user sees may
+                    // be different than what's actually encoded. For example, the
+                    // exponent range of a decimal64 is -383 to 384, as in
+                    // 10e-383 and 10e384. However, for each fractional digit the
+                    // exponent range is decreased by 1. This doesn't change the
+                    // actual range of what's encoded, it just lets you specify
+                    // the same values in different ways. 1.0e-382 and 1.0e385
+                    // are both equivalent to the values mentioned before.
                     let unbiased_integer_exponent =
                         unbiased_exponent.lower(fractional_digits.len());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,19 +132,19 @@ mod tests {
     }
 
     fn nan32(payload: u32) -> f32 {
-        f32::from_bits(f32::NAN.to_bits() | (payload & 0x7fffff))
-    }
+        let f = f32::from_bits(f32::NAN.to_bits() | (payload & 0x7fffff));
 
-    fn snan32(payload: u32) -> f32 {
-        f32::from_bits(nan32(payload).to_bits() & !0x800000)
+        assert!(f.is_nan());
+
+        f
     }
 
     fn nan64(payload: u64) -> f64 {
-        f64::from_bits(f64::NAN.to_bits() | (payload & 0x7ffffffffffff))
-    }
+        let f = f64::from_bits(f64::NAN.to_bits() | (payload & 0x7ffffffffffff));
 
-    fn snan64(payload: u64) -> f64 {
-        f64::from_bits(nan64(payload).to_bits() & !0x8000000000000)
+        assert!(f.is_nan());
+
+        f
     }
 
     #[test]
@@ -314,12 +314,26 @@ mod tests {
 
     #[test]
     fn decimal_roundtrip_f32_nan() {
-        for f in [nan32(0), nan32(42), snan32(0), snan32(42)] {
-            let d = Bitstring::from_f32(f);
-            let df = d.to_f32().unwrap();
+        let f = nan32(0);
 
-            assert_eq!(f.to_bits(), df.to_bits());
-        }
+        let d = Bitstring::from_f32(f);
+
+        assert!(d.is_nan());
+
+        let df = d.to_f32().unwrap();
+
+        assert_eq!(f.to_bits(), df.to_bits());
+    }
+
+    #[test]
+    fn decimal_f32_nan_ignores_payload() {
+        let d1 = Bitstring::from_f32(nan32(0));
+        let d2 = Bitstring::from_f32(nan32(42));
+
+        assert!(d1.is_nan());
+        assert!(d2.is_nan());
+
+        assert_eq!(d1.to_string(), d2.to_string());
     }
 
     #[test]
@@ -348,12 +362,26 @@ mod tests {
 
     #[test]
     fn decimal_roundtrip_f64_nan() {
-        for f in [nan64(0), nan64(42), snan64(0), snan64(42)] {
-            let d = Bitstring::from_f64(f);
-            let df = d.to_f64().unwrap();
+        let f = nan64(0);
+        
+        let d = Bitstring::from_f64(f);
 
-            assert_eq!(f.to_bits(), df.to_bits());
-        }
+        assert!(d.is_nan());
+
+        let df = d.to_f64().unwrap();
+
+        assert_eq!(f.to_bits(), df.to_bits());
+    }
+
+    #[test]
+    fn decimal_f64_nan_ignores_payload() {
+        let d1 = Bitstring::from_f64(nan64(0));
+        let d2 = Bitstring::from_f64(nan64(42));
+
+        assert!(d1.is_nan());
+        assert!(d2.is_nan());
+
+        assert_eq!(d1.as_le_bytes(), d2.as_le_bytes());
     }
 
     #[test]

--- a/src/num.rs
+++ b/src/num.rs
@@ -367,15 +367,13 @@ macro_rules! impl_binary_float {
                 }
 
                 fn nan_payload(&self) -> Option<Self::NanPayload> {
-                    let bits = self.to_bits() & $nan_mask;
-
-                    // Rust doesn't guarantee `NAN` will carry any particular payload
-                    // so if the bitpattern is the same then ignore it
-                    if bits == 0 || (bits == <$f>::NAN.to_bits() & $nan_mask) {
-                        None
-                    } else {
-                        Some(bits as $i)
-                    }
+                    // Rust doesn't guarantee any particular NaN payload for
+                    // the constants `f32::NAN` and `f64::NAN`, so we just
+                    // unconditionally ignore the payload. This means information
+                    // could be lost encoding a binary floating point through a
+                    // decimal, but NaN payloads on binary floating points have
+                    // rather sketchy portability as it is.
+                    None
                 }
             }
         )*

--- a/src/num.rs
+++ b/src/num.rs
@@ -369,7 +369,9 @@ macro_rules! impl_binary_float {
                 fn nan_payload(&self) -> Option<Self::NanPayload> {
                     let bits = self.to_bits() & $nan_mask;
 
-                    if bits == 0 {
+                    // Rust doesn't guarantee `NAN` will carry any particular payload
+                    // so if the bitpattern is the same then ignore it
+                    if bits == 0 || (bits == <$f>::NAN.to_bits() & $nan_mask) {
                         None
                     } else {
                         Some(bits as $i)

--- a/src/num.rs
+++ b/src/num.rs
@@ -12,7 +12,7 @@ use crate::text::{
 };
 
 /**
-Generic binary integers.
+Generic integers.
 */
 pub trait Integer {
     /**
@@ -84,7 +84,7 @@ impl<'a, T: Integer> fmt::Display for AsDisplay<&'a T> {
 }
 
 /**
-Generic binary floating points.
+Generic floating points.
 */
 pub(crate) trait Float {
     /**
@@ -288,7 +288,6 @@ const F32_BUF_SIZE: usize = F32_MAX_MANTISSA_DIGITS + F32_MAX_EXPONENT_DIGITS + 
 // The payload for a NaN is the significand bits, except for the most significant,
 // which is used to identify signaling vs quiet NaNs
 const F32_NAN_PAYLOAD_MASK: u32 = 0b0000_0000_0111_1111_1111_1111_1111_1111u32;
-const F32_SIGNALING_MASK: u32 = 0b0000_0000_1000_0000_0000_0000_0000_0000u32;
 
 // 2f64.powi(52 + 1).log10().ceil() + 1f64
 const F64_MAX_MANTISSA_DIGITS: usize = 17;
@@ -299,11 +298,9 @@ const F64_BUF_SIZE: usize = F64_MAX_MANTISSA_DIGITS + F64_MAX_EXPONENT_DIGITS + 
 // which is used to identify signaling vs quiet NaNs
 const F64_NAN_PAYLOAD_MASK: u64 =
     0b0000_0000_0000_0111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111u64;
-const F64_SIGNALING_MASK: u64 =
-    0b0000_0000_0000_1000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000u64;
 
 macro_rules! impl_binary_float {
-    ($(($f:ty, $i:ty, $u:ty, $text_writer:ty, $nan_mask:ident, $signaling_mask:ident)),*) => {
+    ($(($f:ty, $i:ty, $u:ty, $text_writer:ty, $nan_mask:ident)),*) => {
         $(
             impl Float for $f {
                 type TextWriter = $text_writer;
@@ -327,11 +324,10 @@ macro_rules! impl_binary_float {
                 }
 
                 fn nan(is_negative: bool, is_signaling: bool, payload: Self::NanPayload) -> Self {
-                    let nan = if is_signaling {
-                        <$f>::NAN.to_bits() & !$signaling_mask
-                    } else {
-                        <$f>::NAN.to_bits()
-                    };
+                    // For binary floating points, always encode the NaN as quiet
+                    let _ = is_signaling;
+
+                    let nan = <$f>::NAN.to_bits();
 
                     let f = if payload == 0 {
                         <$f>::from_bits(nan)
@@ -363,7 +359,10 @@ macro_rules! impl_binary_float {
                 }
 
                 fn is_nan_signaling(&self) -> bool {
-                    <$f>::is_nan(*self) && (self.to_bits() & $signaling_mask == 0)
+                    // Signaling for binary floating points isn't particularly
+                    // well defined, so we just unconditionally ignore it and
+                    // assume any NaN is quiet.
+                    false
                 }
 
                 fn nan_payload(&self) -> Option<Self::NanPayload> {
@@ -386,16 +385,14 @@ impl_binary_float!(
         i32,
         u32,
         ArrayTextBuf<F32_BUF_SIZE>,
-        F32_NAN_PAYLOAD_MASK,
-        F32_SIGNALING_MASK
+        F32_NAN_PAYLOAD_MASK
     ),
     (
         f64,
         i64,
         u64,
         ArrayTextBuf<F64_BUF_SIZE>,
-        F64_NAN_PAYLOAD_MASK,
-        F64_SIGNALING_MASK
+        F64_NAN_PAYLOAD_MASK
     )
 );
 


### PR DESCRIPTION
Closes #16 

cc @joseluis. The problem here was that Rust's `f32::NAN` and `f64::NAN` don't guarantee any particular payload. It's not necessarily all zeroes. If we don't fit that payload in our decimal number then instead of truncating it we return `None`.

This fixes that up by ignoring the specific bitpattern that `f32::NAN` and `f64::NAN` happen to be using. Alternatively we could always ignore payloads from `f32` or `f64`. I'd be open to either approach.