### PR TITLE
Make as_le_bytes return a ref of the underlying array

### DIFF
--- a/src/binary/buf/fixed.rs
+++ b/src/binary/buf/fixed.rs
@@ -23,8 +23,8 @@ impl<const N: usize, E> FixedBinaryBuf<N, E> {
         FixedBinaryBuf(buf, PhantomData)
     }
     #[inline]
-    pub(crate) const fn as_le_bytes(&self) -> [u8; N] {
-        self.0
+    pub(crate) const fn as_le_bytes(&self) -> &[u8; N] {
+        &self.0
     }
 }
 

--- a/src/bitstring/arbitrary.rs
+++ b/src/bitstring/arbitrary.rs
@@ -41,7 +41,7 @@ impl BigBitstring {
     /**
     Get a reference to the underlying bitstring buffer.
 
-    This buffer is always stored in little-endain byte-order, regardless of the endianness
+    This buffer is always stored in little-endian byte-order, regardless of the endianness
     of the platform.
     */
     pub fn as_le_bytes(&self) -> &[u8] {

--- a/src/bitstring/dynamic.rs
+++ b/src/bitstring/dynamic.rs
@@ -44,7 +44,7 @@ impl Bitstring {
     /**
     Get a reference to the underlying bitstring buffer.
 
-    This buffer is always stored in little-endain byte-order, regardless of the endianness
+    This buffer is always stored in little-endian byte-order, regardless of the endianness
     of the platform.
     */
     pub fn as_le_bytes(&self) -> &[u8] {

--- a/src/bitstring/fixed128.rs
+++ b/src/bitstring/fixed128.rs
@@ -296,7 +296,7 @@ impl Bitstring128 {
     This matches the internal byte representation of the decimal, regardless of the platform.
     */
     #[inline]
-    pub const fn as_le_bytes(&self) -> [u8; 16] {
+    pub const fn as_le_bytes(&self) -> &[u8; 16] {
         // Even on big-endian platforms we always encode numbers in little-endian order
         self.0.as_le_bytes()
     }

--- a/src/bitstring/fixed32.rs
+++ b/src/bitstring/fixed32.rs
@@ -216,7 +216,7 @@ impl Bitstring32 {
     This matches the internal byte representation of the decimal, regardless of the platform.
     */
     #[inline]
-    pub const fn as_le_bytes(&self) -> [u8; 4] {
+    pub const fn as_le_bytes(&self) -> &[u8; 4] {
         // Even on big-endian platforms we always encode numbers in little-endian order
         self.0.as_le_bytes()
     }

--- a/src/bitstring/fixed64.rs
+++ b/src/bitstring/fixed64.rs
@@ -280,7 +280,7 @@ impl Bitstring64 {
     This matches the internal byte representation of the decimal, regardless of the platform.
     */
     #[inline]
-    pub const fn as_le_bytes(&self) -> [u8; 8] {
+    pub const fn as_le_bytes(&self) -> &[u8; 8] {
         // Even on big-endian platforms we always encode numbers in little-endian order
         self.0.as_le_bytes()
     }


### PR DESCRIPTION
cc @joseluis

Since we're able to return a reference for `as_le_bytes` I think it would be best to do so, that way you can keep any lifetime constraints such as when converting to a `&[u8]`, and avoid copying the whole buffer if you don't need to.