### PR TITLE
Prepare for 0.2.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "decstr"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add `decstr` to your `Cargo.toml`:
 
 ```toml
 [dependencies.decstr]
-version = "0.1.3"
+version = "0.2.0"
 ```
 
 Any Rust primitive numeric type can be encoded in a `Bitstring`:


### PR DESCRIPTION
cc @joseluis I figure it would be good to keep the releases rolling. We can easily do a `0.3.0` release if there are any other breaking changes needed.

## What's Changed
* Update expect message in decimal_from_int by @KodrAus in https://github.com/KodrAus/decstr/pull/10
* fix warnings and add missing derives by @joseluis in https://github.com/KodrAus/decstr/pull/12
* Add a test for encoding zero values by @KodrAus in https://github.com/KodrAus/decstr/pull/13
* constification by @joseluis in https://github.com/KodrAus/decstr/pull/14
* Ignore the specific NAN encoded by f32/f64::NAN by @KodrAus in https://github.com/KodrAus/decstr/pull/18
* add consts `MIN_10_EXP`, `MAX_10_EXP` by @joseluis in https://github.com/KodrAus/decstr/pull/21
* Make as_le_bytes return a ref of the underlying array by @KodrAus in https://github.com/KodrAus/decstr/pull/20
* Add tests for min/max exponents by @KodrAus in https://github.com/KodrAus/decstr/pull/22